### PR TITLE
Detect if AAC stream is USAC and try to fallback to FDK if so

### DIFF
--- a/libavcodec/aacdec_template.c
+++ b/libavcodec/aacdec_template.c
@@ -1032,6 +1032,12 @@ static int decode_audio_specific_config_gb(AACDecContext *ac,
                                               m4ac, m4ac->chan_config)) < 0)
             return ret;
         break;
+    case AOT_USAC:
+    case AOT_USAC_NOSBR:
+        av_log(avctx, AV_LOG_WARNING,
+            "USAC is not supported by the native decoder."
+            " libfdk_aac can be used instead\n");
+        return AVERROR_DECODER_NOT_FOUND;
     default:
         avpriv_report_missing_feature(avctx,
                                       "Audio object type %s%d",

--- a/libavcodec/allcodecs.c
+++ b/libavcodec/allcodecs.c
@@ -766,6 +766,7 @@ extern const FFCodec ff_libdav1d_decoder;
 extern const FFCodec ff_libdavs2_decoder;
 extern const FFCodec ff_libfdk_aac_encoder;
 extern const FFCodec ff_libfdk_aac_decoder;
+extern const FFCodec ff_libfdk_usac_decoder;
 extern const FFCodec ff_libgsm_encoder;
 extern const FFCodec ff_libgsm_decoder;
 extern const FFCodec ff_libgsm_ms_encoder;

--- a/libavcodec/codec_desc.c
+++ b/libavcodec/codec_desc.c
@@ -3721,6 +3721,14 @@ static const AVCodecDescriptor codec_descriptors[] = {
         .name      = "anull",
         .long_name = NULL_IF_CONFIG_SMALL("Null audio codec"),
     },
+    {
+        .id        = AV_CODEC_ID_USAC,
+        .type      = AVMEDIA_TYPE_AUDIO,
+        .name      = "usac",
+        .long_name = NULL_IF_CONFIG_SMALL("AAC USAC"),
+        .props     = AV_CODEC_PROP_INTRA_ONLY | AV_CODEC_PROP_LOSSY,
+        .profiles  = NULL_IF_CONFIG_SMALL(ff_aac_profiles),
+    },
 };
 
 static int descriptor_compare(const void *key, const void *member)

--- a/libavcodec/codec_id.h
+++ b/libavcodec/codec_id.h
@@ -609,6 +609,8 @@ enum AVCodecID {
      * Null encoder/decoder discard all input and never return any output.
      */
     AV_CODEC_ID_ANULL,
+
+    AV_CODEC_ID_USAC,
 };
 
 /**

--- a/libavcodec/libfdk-aacdec.c
+++ b/libavcodec/libfdk-aacdec.c
@@ -487,3 +487,23 @@ const FFCodec ff_libfdk_aac_decoder = {
     .caps_internal  = FF_CODEC_CAP_INIT_CLEANUP,
     .p.wrapper_name = "libfdk",
 };
+
+const FFCodec ff_libfdk_usac_decoder = {
+    .p.name         = "libfdk_aac",
+    CODEC_LONG_NAME("Fraunhofer FDK AAC (USAC)"),
+    .p.type         = AVMEDIA_TYPE_AUDIO,
+    .p.id           = AV_CODEC_ID_USAC,
+    .priv_data_size = sizeof(FDKAACDecContext),
+    .init           = fdk_aac_decode_init,
+    FF_CODEC_DECODE_CB(fdk_aac_decode_frame),
+    .close          = fdk_aac_decode_close,
+    .flush          = fdk_aac_decode_flush,
+    .p.capabilities = AV_CODEC_CAP_DR1 | AV_CODEC_CAP_CHANNEL_CONF
+#if FDKDEC_VER_AT_LEAST(2, 5) // 2.5.10
+                      | AV_CODEC_CAP_DELAY
+#endif
+    ,
+    .p.priv_class   = &fdk_aac_dec_class,
+    .caps_internal  = FF_CODEC_CAP_INIT_CLEANUP,
+    .p.wrapper_name = "libfdk",
+};


### PR DESCRIPTION
 I know this is probably not the right way to do it. But I don't know what is, and I wanted to demonstrate the issue.

 Note that forcing input codec is neither intuitive, nor is the option always available to do so. `ffprobe` doesn't have a `-c` option. And even people using `ffmpeg` in scripts wouldn't necessarily realize that this is something they have to take account of.