### PR TITLE
Electronic Arts ADPCM IMA XBOX decoding

### DIFF
--- a/libavcodec/adpcm.c
+++ b/libavcodec/adpcm.c
@@ -1334,7 +1334,7 @@ static int adpcm_decode_frame(AVCodecContext *avctx, AVFrame *frame,
         for (int n = 0; n < nb_samples / 8; n++) {
             for (int i = 0; i < channels; i++) {
                 ADPCMChannelStatus *cs = &c->status[i];
-                samples = &samples_p[i][1 + n * 8];
+                samples = &samples_p[i][n * 8];
                 for (int m = 0; m < 8; m += 2) {
                     int v = bytestream2_get_byteu(&gb);
                     samples[m    ] = adpcm_ima_expand_nibble(cs, v & 0x0F, 3);

--- a/libavformat/electronicarts.c
+++ b/libavformat/electronicarts.c
@@ -407,6 +407,9 @@ static int process_ea_header(AVFormatContext *s)
         if (ea->big_endian)
             size = av_bswap32(size);
 
+        if (avio_feof(pb))
+            break;
+
         if (size < 8) {
             av_log(s, AV_LOG_ERROR, "chunk size too small\n");
             return AVERROR_INVALIDDATA;

--- a/libavformat/electronicarts.c
+++ b/libavformat/electronicarts.c
@@ -270,6 +270,9 @@ static int process_audio_header_elements(AVFormatContext *s)
         case 16:
             ea->audio_codec = AV_CODEC_ID_MP3;
             break;
+        case 20:
+            ea->audio_codec = AV_CODEC_ID_ADPCM_IMA_XBOX;
+            break;
         case 23:
             ea->audio_codec = AV_CODEC_ID_EALAYER3MULTI;
             break;
@@ -590,12 +593,22 @@ static int ea_read_header(AVFormatContext *s)
         st->codecpar->codec_tag             = 0;   /* no tag */
         st->codecpar->ch_layout.nb_channels = ea->num_channels;
         st->codecpar->sample_rate           = ea->sample_rate;
-        st->codecpar->bits_per_coded_sample = ea->bytes * 8;
+        if (ea->audio_codec == AV_CODEC_ID_ADPCM_IMA_XBOX)
+            st->codecpar->bits_per_coded_sample = 4;
+        else
+            st->codecpar->bits_per_coded_sample = ea->bytes * 8;
         st->codecpar->bit_rate              = (int64_t)ea->num_channels *
                                               st->codecpar->sample_rate *
                                               st->codecpar->bits_per_coded_sample / 4;
-        st->codecpar->block_align           = ea->num_channels *
-                                              st->codecpar->bits_per_coded_sample;
+        if (ea->audio_codec == AV_CODEC_ID_ADPCM_IMA_XBOX) {
+            st->codecpar->block_align = 0x24;
+            if (ea->num_channels != 1) {
+                avpriv_report_missing_feature(s, "multichannel ADPCM IMA XBOX");
+                return AVERROR_PATCHWELCOME;
+            }
+        } else
+            st->codecpar->block_align = ea->num_channels *
+                                        st->codecpar->bits_per_coded_sample;
         ea->audio_stream_index           = st->index;
         st->start_time                   = 0;
         return 0;
@@ -671,6 +684,10 @@ static int ea_read_packet(AVFormatContext *s, AVPacket *pkt)
                     v = av_bswap32(v);
                 num_samples = v;
                 avio_seek(pb, -4, SEEK_CUR);
+            } else if (ea->audio_codec == AV_CODEC_ID_ADPCM_IMA_XBOX) {
+                num_samples = avio_rl32(pb);
+                avio_skip(pb, 4);
+                chunk_size -= 8;
             }
 
             if (partial_packet) {
@@ -718,6 +735,7 @@ static int ea_read_packet(AVFormatContext *s, AVPacket *pkt)
             case AV_CODEC_ID_UTK:
             case AV_CODEC_ID_UTK_R3:
             case AV_CODEC_ID_EALAYER3MULTI:
+            case AV_CODEC_ID_ADPCM_IMA_XBOX:
                 pkt->duration = num_samples;
                 break;
             case AV_CODEC_ID_ADPCM_PSX:


### PR DESCRIPTION
Sample: http://pross.sdf.org/sandpit/tone.asf

SX.EXE can generate nb_channel > 1 XBOX ADPCM files that use a similar style to multichannel EA Layer 3. These are presently not supported. I don't really want to add another AV_CODEC_ID for these unless somebody requests them.