### PR TITLE
avformat/riff: map 0069 twocc to ADPCM IMA XBOX decoder

### DIFF
--- a/libavformat/riff.c
+++ b/libavformat/riff.c
@@ -565,7 +565,7 @@ const AVCodecTag ff_codec_wav_tags[] = {
     /* rogue format number */
     { AV_CODEC_ID_ADPCM_IMA_DK3,   0x0062 },
     { AV_CODEC_ID_ADPCM_G726,      0x0064 },
-    { AV_CODEC_ID_ADPCM_IMA_WAV,   0x0069 },
+    { AV_CODEC_ID_ADPCM_IMA_XBOX,  0x0069 },
     { AV_CODEC_ID_METASOUND,       0x0075 },
     { AV_CODEC_ID_G729,            0x0083 },
     { AV_CODEC_ID_AAC,             0x00ff },


### PR DESCRIPTION
Sample: https://github.com/vgmstream/vgmstream/files/15491901/flyaround_06.zip