### PR TITLE
L&H CELP various fixes

### DIFF
--- a/libavcodec/lhcelpdata.h
+++ b/libavcodec/lhcelpdata.h
@@ -102,8 +102,8 @@ static const int16_t lhcelp_cb4[16] = {
     22609, 23592, 24576, 25395, 26214, 27115, 28098, 29081
 };
 
-static const int16_t *lhcelp_cbs[4] = {
-    lhcelp_cb1, lhcelp_cb2, lhcelp_cb3, lhcelp_cb4
+static const int16_t *lhcelp_cbs[5] = {
+    lhcelp_cb0, lhcelp_cb1, lhcelp_cb2, lhcelp_cb3, lhcelp_cb4
 };
 
 static const int16_t lhcelp_scale_a0[9] = {

--- a/libavcodec/lhcelpdec.c
+++ b/libavcodec/lhcelpdec.c
@@ -138,7 +138,7 @@ static void process_coeffs2(int16_t *coeffs)
         if (coeff <= table[0])
             table--;
 
-        num = (int16_t)(coeff - table[0]) << 16;
+        num = (coeff - table[0]) << 16;
         den = (table[1] - table[0]) << 1;
         new_coeff = table[-jump - 1] - ((int16_t)(num / den + offset) >> shift);
 


### PR DESCRIPTION
About the naive overlapping memcpy: it is required to reproduce output of the reference decoder.