### PR TITLE
avformat/libmodplug: improve probing for STM

### DIFF
--- a/libavformat/libmodplug.c
+++ b/libavformat/libmodplug.c
@@ -24,6 +24,7 @@
 
 #define MODPLUG_STATIC
 #include <libmodplug/modplug.h>
+#include "libavutil/intreadwrite.h"
 #include "libavutil/avstring.h"
 #include "libavutil/eval.h"
 #include "libavutil/mem.h"
@@ -367,6 +368,12 @@ static const char modplug_extensions[] = "669,abc,amf,ams,dbm,dmf,dsm,far,it,mdl
 static int modplug_probe(const AVProbeData *p)
 {
     if (av_match_ext(p->filename, modplug_extensions)) {
+        if (av_match_ext(p->filename, "stm")) {
+            if ((memcmp(p->buf + 20, "!SCREAM!", 8) && memcmp(p->buf + 20, "BMOD2STM", 8))
+                || AV_RL8(p->buf, 28) != 0x1A || AV_RL8(p->buf, 29) != 2)
+                return 0;
+            return AVPROBE_SCORE_MAX;
+        }
         if (p->buf_size < 16384)
             return AVPROBE_SCORE_EXTENSION/2-1;
         else


### PR DESCRIPTION
Improves probing for STM files based off what libmodplug checks themselves https://github.com/Konstanty/libmodplug/blob/master/src/load_stm.cpp to not interfere with the video format used by Sonic CD which I'm adding right now.