### PR TITLE
avformat/fsb: fix NDSP_SI, add PSX ADPCM & XWMA

### DIFF
--- a/libavformat/fsb.c
+++ b/libavformat/fsb.c
@@ -523,6 +523,118 @@ static int fsb_read_header(AVFormatContext *s)
                         }
                         avio_skip(pb, extraflag_size);
                         break;
+                    case 0x0a:
+                        switch (codec) {
+                        case 0x0E:
+                            {
+                                int format_id = avio_rb16(pb);
+                                extraflag_size -= 2;
+                                par->block_align = avio_rb16(pb);
+                                extraflag_size -= 2;
+                                if (!par->block_align) par->block_align = 2230;
+                                par->bit_rate = avio_rb32(pb);
+                                extraflag_size -= 4;
+                                par->bits_per_coded_sample = 16;
+
+                                if (format_id == 0x0161) {
+                                    par->codec_id = AV_CODEC_ID_WMAV2;
+
+                                    int ch = channels;
+                                    int sr = sample_rate;
+                                    int br = par->bit_rate;
+
+                                    if (ch == 1) {
+                                        if (sr == 22050 && (br==48000 || br==192000))
+                                            br = 20000;
+                                        else if (sr == 32000 && (br==48000 || br==192000))
+                                            br = 20000;
+                                        else if (sr == 44100 && (br==96000 || br==192000))
+                                            br = 48000;
+                                    }
+                                    else if (ch == 2) {
+                                        if (sr == 22050 && (br==48000 || br==192000))
+                                            br = 32000;
+                                        else if (sr == 32000 && (br==192000))
+                                            br = 48000;
+                                    }
+
+                                    par->bit_rate = br;
+
+                                    if ((ret = ff_alloc_extradata(par, 6)) < 0)
+                                        return ret;
+
+                                    memset(par->extradata, 0, par->extradata_size);
+                                    par->extradata[4] = 31;
+                                } else if (format_id == 0x0162) {
+                                    par->codec_id = AV_CODEC_ID_WMAPRO;
+
+                                    if ((ret = ff_alloc_extradata(par, 18)) < 0)
+                                        return ret;
+
+                                    memset(par->extradata, 0, par->extradata_size);
+                                    par->extradata[ 0] = par->bits_per_coded_sample;
+                                    par->extradata[14] = 224;
+                                } else {
+                                    avpriv_request_sample(s, "Unexpected format %d", format_id);
+                                    return AVERROR_PATCHWELCOME;
+                                }
+
+                                if (extraflag_size > 0) {
+                                    int i;
+                                    uint32_t dpds_table_size, bps;
+                                    uint32_t *dpds_table = NULL;
+
+                                    if (extraflag_size & 3) {
+                                        av_log(s, AV_LOG_WARNING,
+                                            "dpds chunk size %"PRId64" not divisible by 4\n", extraflag_size);
+                                    }
+
+                                    bps = (channels * par->bits_per_coded_sample) >> 3;
+                                    if (!bps) {
+                                        av_log(s, AV_LOG_ERROR,
+                                            "Invalid bits_per_coded_sample %d for %d channels\n",
+                                            par->bits_per_coded_sample, channels);
+                                        return AVERROR_INVALIDDATA;
+                                    }
+
+                                    dpds_table_size = extraflag_size / 4;
+                                    if (dpds_table_size == 0 || dpds_table_size >= INT_MAX / 4) {
+                                        av_log(s, AV_LOG_ERROR,
+                                            "dpds chunk size %"PRId64" invalid\n", extraflag_size);
+                                        return AVERROR_INVALIDDATA;
+                                    }
+
+                                    dpds_table = av_malloc_array(dpds_table_size, sizeof(uint32_t));
+                                    if (!dpds_table)
+                                        return AVERROR(ENOMEM);
+
+                                    for (i = 0; i < dpds_table_size; ++i) {
+                                        if (extraflag_size < 4) {
+                                            av_free(dpds_table);
+                                            return AVERROR_INVALIDDATA;
+                                        }
+                                        dpds_table[i] = avio_rb32(pb);
+                                        extraflag_size -= 4;
+                                    }
+
+                                    st->duration = (uint64_t)dpds_table[dpds_table_size - 1] / bps;
+                                    for (i = 0; i < dpds_table_size; ++i) {
+                                        av_add_index_entry(st,
+                                                           fst->start_offset + (i+1) * st->codecpar->block_align,
+                                                           dpds_table[i] / bps,
+                                                           st->codecpar->block_align,
+                                                           0,AVINDEX_KEYFRAME);
+                                    }
+
+                                    av_free(dpds_table);
+                                } else {
+                                    st->duration = av_rescale((fst->stop_offset - fst->start_offset)<<3, sample_rate, par->bit_rate);
+                                }
+                            }
+                            break;
+                        }
+                        avio_skip(pb, extraflag_size);
+                        break;
                     case 0x0b:
                         fst->extradata = av_calloc(extraflag_size, sizeof(*fst->extradata));
                         if (!fst->extradata)
@@ -605,6 +717,10 @@ static int fsb_read_header(AVFormatContext *s)
                 if (par->block_align == 0)
                     par->block_align = 1024;
                 sti->need_parsing = AVSTREAM_PARSE_FULL;
+                break;
+            case 0x0E:
+                /* XWMA */
+                sti->need_parsing = AVSTREAM_PARSE_NONE;
                 break;
             case 0x0F:
                 par->codec_id = AV_CODEC_ID_VORBIS;


### PR DESCRIPTION
FSB5 PSX ADPCM & FSB2/3/4 NDSP_SI work perfectly fine
[fsb3_ndsp_si.zip](https://github.com/user-attachments/files/23143142/fsb3_ndsp_si.zip)
[fsb5_psx_multi.zip](https://github.com/user-attachments/files/23143144/fsb5_psx_multi.zip)
I've also found a FSB1 file with only one stream and can confirm that removing the coeff reading didn't hurt it in any way
[fsb1_single.zip](https://github.com/user-attachments/files/23143149/fsb1_single.zip)

However XWMA doesn't work yet, getting lots of errors:
[xwma.log](https://github.com/user-attachments/files/23143158/xwma.log)
[fsb5_xwma_multi.zip](https://github.com/user-attachments/files/23143162/fsb5_xwma_multi.zip)
