### PR TITLE
avformat: add fullsize to AVProbeData

### DIFF
--- a/libavformat/avformat.h
+++ b/libavformat/avformat.h
@@ -452,6 +452,7 @@ typedef struct AVProbeData {
     const char *filename;
     unsigned char *buf; /**< Buffer must have AVPROBE_PADDING_SIZE of extra allocated bytes filled with zero. */
     int buf_size;       /**< Size of buf except extra allocated bytes */
+    int fullsize;      /**< Full, original buffer size when known. */
     const char *mime_type; /**< mime_type, when known. */
 } AVProbeData;
 

--- a/libavformat/demux.c
+++ b/libavformat/demux.c
@@ -159,7 +159,7 @@ static int init_input(AVFormatContext *s, const char *filename,
                       AVDictionary **options)
 {
     int ret;
-    AVProbeData pd = { filename, NULL, 0 };
+    AVProbeData pd = { filename, NULL, 0, 0 };
     int score = AVPROBE_SCORE_RETRY;
 
     if (s->pb) {

--- a/libavformat/format.c
+++ b/libavformat/format.c
@@ -286,6 +286,9 @@ int av_probe_input_buffer2(AVIOContext *pb, const AVInputFormat **fmt,
         }
     }
 
+    if (pb->buffer_size > 0)
+        pd.fullsize = pb->buffer_size - offset;
+
     for (probe_size = PROBE_BUF_MIN; probe_size <= max_probe_size && !*fmt && !eof;
          probe_size = FFMIN(probe_size << 1,
                             FFMAX(max_probe_size, probe_size + 1))) {

--- a/libavformat/img2dec.c
+++ b/libavformat/img2dec.c
@@ -411,6 +411,7 @@ int ff_img_read_packet(AVFormatContext *s1, AVPacket *pkt)
             pd.buf = header;
             pd.buf_size = ret;
             pd.filename = filename.str;
+            pd.fullsize = size;
 
             ifmt = ffifmt(av_probe_input_format3(&pd, 1, &score));
             if (ifmt && ifmt->read_packet == ff_img_read_packet && ifmt->raw_codec_id)


### PR DESCRIPTION
This would be useful for formats that are hard to detect but where the file size can be calculated from header values or for example for raw PSX ADPCM where the filesize has to be a multiple of 0x10