### PR TITLE
avcodec/tableprint_vlc: Fix build failure with hardcoded tables

### DIFF
--- a/libavcodec/tableprint_vlc.h
+++ b/libavcodec/tableprint_vlc.h
@@ -29,6 +29,7 @@
 #define ff_tlog(a, ...) while(0)
 #define AVUTIL_MEM_H
 #define av_malloc(s) NULL
+#define av_mallocz(s) NULL
 #define av_malloc_array(a, b) NULL
 #define av_realloc_f(p, o, n) NULL
 #define av_free(p) while(0)


### PR DESCRIPTION
Broken since 2bb95c262fcb2df239197971e81367967ee88186.