### PR TITLE
avcodec/tableprint_vlc: Remove unused av_malloc define

### DIFF
--- a/libavcodec/tableprint_vlc.h
+++ b/libavcodec/tableprint_vlc.h
@@ -28,7 +28,6 @@
 #define ff_dlog(a, ...) while(0)
 #define ff_tlog(a, ...) while(0)
 #define AVUTIL_MEM_H
-#define av_malloc(s) NULL
 #define av_mallocz(s) NULL
 #define av_malloc_array(a, b) NULL
 #define av_realloc_f(p, o, n) NULL


### PR DESCRIPTION
The only usage was removed.
Fixes: 9876643749407ea34c8e44ca7d72fa22ec47119d