### PR TITLE
avcodec/mjpegdec: Disallow unchecked bitstream reader

### DIFF
--- a/libavcodec/mjpegdec.c
+++ b/libavcodec/mjpegdec.c
@@ -30,6 +30,8 @@
  * MJPEG decoder.
  */
 
+#define UNCHECKED_BITSTREAM_READER 0
+
 #include "config_components.h"
 
 #include "libavutil/attributes.h"


### PR DESCRIPTION
Avoid crash at the presence of unchecked bitstream reader after commit 41931ecb3d56c64b25660730b5aacf43d08229c8 by explicitly disabling it for this decoder.