### PR TITLE
configure: fix schannel_extralibs

### DIFF
--- a/configure
+++ b/configure
@@ -7347,7 +7347,7 @@ enabled schannel &&
     check_func_headers "windows.h ncrypt.h" NCryptOpenStorageProvider -DSECURITY_WIN32 -lncrypt &&
     check_func_headers "windows.h wincrypt.h" CertCreateSelfSignCertificate -DSECURITY_WIN32 -lcrypt32 &&
     test_cpp_condition winerror.h "defined(SEC_I_CONTEXT_EXPIRED)" &&
-    schannel_extralibs="-lsecur32" ||
+    schannel_extralibs="-lsecur32 -lncrypt -lcrypt32" ||
         disable schannel
 
 enabled schannel && check_cc dtls_protocol "windows.h security.h schnlsp.h" "int i = SECPKG_ATTR_DTLS_MTU;" -DSECURITY_WIN32


### PR DESCRIPTION
Hi,

I got hit with a load of linking errors, turns out that with this recent commit: https://github.com/librempeg/librempeg/commit/15367e7714b5c37a94d5b039050fb3836aa6ff37

A little bit is missing, as can be seen here: https://github.com/FFmpeg/FFmpeg/commit/90fa9636efff84ec5a4b06815722c08188dca551#diff-90d08e583c4c9c6f391b2ae90f819f600a6326928ea9512c9e0c6d98e9f29ac2R7271-R7272

