### PR TITLE
avfilter/af_afade: fix acrossfade to wait for all samples and process in chunks

### DIFF
--- a/libavfilter/af_afade.c
+++ b/libavfilter/af_afade.c
@@ -46,10 +46,6 @@ typedef struct AudioFadeContext {
     int passthrough;
     int64_t pts;
 
-    /* Incremental crossfade state */
-    int crossfade_in_progress;
-    int64_t crossfade_offset;
-
     void (*fade_samples)(uint8_t **dst, uint8_t * const *src,
                          int nb_samples, int channels, int direction,
                          int64_t start, int64_t range, int curve,
@@ -367,54 +363,7 @@ static int pass_samples(AVFilterLink *inlink, AVFilterLink *outlink, unsigned nb
     return ff_filter_frame(outlink, in);
 }
 
-/* Process a chunk of crossfade samples incrementally.
- * This consumes samples as they become available, reducing peak memory usage
- * by not waiting for all input 1 samples to be buffered. */
-static int pass_crossfade_chunk(AVFilterContext *ctx, int chunk_samples)
-{
-    AudioFadeContext *s = ctx->priv;
-    AVFilterLink *outlink = ctx->outputs[0];
-    AVFrame *out, *cf[2] = { NULL };
-    int ret;
-
-    out = ff_get_audio_buffer(outlink, chunk_samples);
-    if (!out)
-        return AVERROR(ENOMEM);
-
-    ret = ff_inlink_consume_samples(ctx->inputs[0], chunk_samples, chunk_samples, &cf[0]);
-    if (ret < 0) {
-        av_frame_free(&out);
-        return ret;
-    }
-
-    ret = ff_inlink_consume_samples(ctx->inputs[1], chunk_samples, chunk_samples, &cf[1]);
-    if (ret < 0) {
-        av_frame_free(&out);
-        ff_graph_frame_free(ctx, &cf[0]);
-        return ret;
-    }
-
-    s->crossfade_samples(out->extended_data, cf[0]->extended_data,
-                         cf[1]->extended_data,
-                         chunk_samples, s->nb_samples, s->crossfade_offset,
-                         out->ch_layout.nb_channels,
-                         s->curve, s->curve2);
-    out->pts = s->pts;
-    s->pts += av_rescale_q(chunk_samples,
-        (AVRational){ 1, outlink->sample_rate }, outlink->time_base);
-
-    s->crossfade_offset += chunk_samples;
-
-    /* Check if crossfade is complete */
-    if (s->crossfade_offset >= s->nb_samples) {
-        s->crossfade_in_progress = 0;
-        s->passthrough = 1;
-    }
-
-    ff_graph_frame_free(ctx, &cf[0]);
-    ff_graph_frame_free(ctx, &cf[1]);
-    return ff_filter_frame(outlink, out);
-}
+#define CROSSFADE_CHUNK_SIZE 8192
 
 static int pass_crossfade(AVFilterContext *ctx)
 {
@@ -424,34 +373,53 @@ static int pass_crossfade(AVFilterContext *ctx)
     int ret;
 
     if (s->overlap) {
-        out = ff_get_audio_buffer(outlink, s->nb_samples);
-        if (!out)
-            return AVERROR(ENOMEM);
+        int64_t offset = 0;
 
-        ret = ff_inlink_consume_samples(ctx->inputs[0], s->nb_samples, s->nb_samples, &cf[0]);
-        if (ret < 0) {
-            av_frame_free(&out);
-            return ret;
+        /* Process crossfade in chunks to reduce peak memory usage.
+         * Instead of allocating one large output buffer, we process
+         * and output smaller chunks, freeing input samples as we go. */
+        while (offset < s->nb_samples) {
+            int chunk = FFMIN(CROSSFADE_CHUNK_SIZE, (int)(s->nb_samples - offset));
+
+            out = ff_get_audio_buffer(outlink, chunk);
+            if (!out)
+                return AVERROR(ENOMEM);
+
+            ret = ff_inlink_consume_samples(ctx->inputs[0], chunk, chunk, &cf[0]);
+            if (ret < 0) {
+                av_frame_free(&out);
+                return ret;
+            }
+
+            ret = ff_inlink_consume_samples(ctx->inputs[1], chunk, chunk, &cf[1]);
+            if (ret < 0) {
+                av_frame_free(&out);
+                ff_graph_frame_free(ctx, &cf[0]);
+                return ret;
+            }
+
+            s->crossfade_samples(out->extended_data, cf[0]->extended_data,
+                                 cf[1]->extended_data,
+                                 chunk, s->nb_samples, offset,
+                                 out->ch_layout.nb_channels,
+                                 s->curve, s->curve2);
+            out->pts = s->pts;
+            s->pts += av_rescale_q(chunk,
+                (AVRational){ 1, outlink->sample_rate }, outlink->time_base);
+
+            ff_graph_frame_free(ctx, &cf[0]);
+            ff_graph_frame_free(ctx, &cf[1]);
+            cf[0] = cf[1] = NULL;
+
+            ret = ff_filter_frame(outlink, out);
+            if (ret < 0)
+                return ret;
+
+            offset += chunk;
         }
 
-        ret = ff_inlink_consume_samples(ctx->inputs[1], s->nb_samples, s->nb_samples, &cf[1]);
-        if (ret < 0) {
-            av_frame_free(&out);
-            return ret;
-        }
-
-        s->crossfade_samples(out->extended_data, cf[0]->extended_data,
-                             cf[1]->extended_data,
-                             s->nb_samples, s->nb_samples, 0,
-                             out->ch_layout.nb_channels,
-                             s->curve, s->curve2);
-        out->pts = s->pts;
-        s->pts += av_rescale_q(s->nb_samples,
-            (AVRational){ 1, outlink->sample_rate }, outlink->time_base);
         s->passthrough = 1;
-        ff_graph_frame_free(ctx, &cf[0]);
-        ff_graph_frame_free(ctx, &cf[1]);
-        return ff_filter_frame(outlink, out);
+        return 0;
     } else {
         out = ff_get_audio_buffer(outlink, s->nb_samples);
         if (!out)
@@ -509,67 +477,16 @@ static int activate(AVFilterContext *ctx)
         FF_FILTER_FORWARD_WANTED(outlink, ctx->inputs[1]);
     }
 
-    /* Handle incremental crossfade in progress (overlap mode only) */
-    if (s->crossfade_in_progress) {
-        int64_t remaining = s->nb_samples - s->crossfade_offset;
-        int available0 = ff_inlink_queued_samples(ctx->inputs[0]);
-        int available1 = ff_inlink_queued_samples(ctx->inputs[1]);
-        int chunk = FFMIN3(available0, available1, remaining);
-
-        if (chunk > 0) {
-            return pass_crossfade_chunk(ctx, chunk);
-        } else if (ff_outlink_frame_wanted(outlink)) {
-            /* Check if input 1 ended prematurely */
-            if (check_input(ctx->inputs[1])) {
-                s->status[1] = AVERROR_EOF;
-                ff_outlink_set_status(outlink, AVERROR_EOF, AV_NOPTS_VALUE);
-                return 0;
-            }
-            /* Need more samples from input 1 */
-            ff_inlink_request_frame(ctx->inputs[1]);
-            return 0;
-        }
-        return 0;
-    }
-
     nb_samples = ff_inlink_queued_samples(ctx->inputs[0]);
     if (nb_samples  > s->nb_samples) {
         nb_samples -= s->nb_samples;
         s->passthrough = 1;
         return pass_samples(ctx->inputs[0], outlink, nb_samples, &s->pts);
-    } else if (s->status[0] && nb_samples >= s->nb_samples) {
-        /* Input 0 has EOF and has exactly nb_samples remaining.
-         * For overlap mode, use incremental crossfade to reduce memory.
-         * For non-overlap mode, use original blocking behavior. */
-        if (s->overlap) {
-            int available1 = ff_inlink_queued_samples(ctx->inputs[1]);
-            if (available1 > 0) {
-                /* Start incremental crossfade */
-                s->crossfade_in_progress = 1;
-                s->crossfade_offset = 0;
-                return pass_crossfade_chunk(ctx, FFMIN3(nb_samples, available1, s->nb_samples));
-            } else if (ff_outlink_frame_wanted(outlink)) {
-                /* Check if input 1 ended before crossfade could start */
-                if (check_input(ctx->inputs[1])) {
-                    s->status[1] = AVERROR_EOF;
-                    ff_outlink_set_status(outlink, AVERROR_EOF, AV_NOPTS_VALUE);
-                    return 0;
-                }
-                /* Start crossfade mode, request input 1 */
-                s->crossfade_in_progress = 1;
-                s->crossfade_offset = 0;
-                ff_inlink_request_frame(ctx->inputs[1]);
-                return 0;
-            }
-        } else {
-            /* Non-overlap mode: wait for all samples (original behavior) */
-            if (ff_inlink_queued_samples(ctx->inputs[1]) >= s->nb_samples) {
-                return pass_crossfade(ctx);
-            } else if (ff_outlink_frame_wanted(outlink)) {
-                ff_inlink_request_frame(ctx->inputs[1]);
-                return 0;
-            }
-        }
+    } else if (s->status[0] && nb_samples >= s->nb_samples &&
+               ff_inlink_queued_samples(ctx->inputs[1]) >= s->nb_samples) {
+        /* Both inputs have enough samples - start crossfade.
+         * pass_crossfade processes in chunks to reduce peak memory. */
+        return pass_crossfade(ctx);
     } else if (ff_outlink_frame_wanted(outlink)) {
         if (!s->status[0] && check_input(ctx->inputs[0]))
             s->status[0] = AVERROR_EOF;


### PR DESCRIPTION
## Summary
This PR fixes a bug introduced in PR #169 and replaces the buggy incremental crossfade implementation with a correct chunked output approach.

## Bug Fixed
PR #169 started crossfade processing as soon as ANY samples were available from input 1, instead of waiting for the full crossfade duration. This caused:
- Incorrect output when input 2 is shorter than crossfade duration
- Hangs/slow processing in edge cases

## Changes
1. **Removed buggy incremental state machine** - The `crossfade_in_progress` and `crossfade_offset` state tracking is removed
2. **Restored correct waiting behavior** - Now waits for `nb_samples` from both inputs before starting crossfade
3. **Added chunked output processing** - Processes output in 8192-sample chunks to reduce peak memory

## Validation Results

### Bug Reproduction (10s + 3s inputs, 5s crossfade)
| Version | Output | Runtime | Status |
|---------|--------|---------|--------|
| Simple (correct baseline) | 5s | 0.1s | CORRECT |
| Buggy (PR #169) | 8s | 25s | **BROKEN** |
| Fixed (this PR) | 5s | 0.1s | CORRECT |

### Memory Comparison (Simple vs Fixed)
| Duration | Simple | Fixed | Reduction |
|----------|--------|-------|-----------|
| 1 min | 42 MB | 29 MB | **31%** |
| 10 min | 328 MB | 186 MB | **43%** |
| 30 min | 872 MB | 524 MB | **39%** |
| 60 min | 1668 MB | 1022 MB | **38%** |

### CPU Comparison (3 runs averaged)
| Duration | Simple | Fixed | Change |
|----------|--------|-------|--------|
| 1 min | 0.20s | 0.19s | **-5%** |
| 10 min | 0.32s | 0.32s | 0% |
| 30 min | 0.60s | 0.58s | **-3%** |
| 60 min | 1.02s | 0.97s | **-4%** |

### Output Verification
All durations (1m, 10m, 30m, 60m) produce **byte-identical output** (MD5 match) compared to simple implementation.

<details>
<summary>Reproduction Script</summary>

```bash
#!/bin/bash
# Reproduces all benchmark results. Requires: Docker, git
set -e

WORKDIR=$(mktemp -d)
trap "rm -rf $WORKDIR" EXIT
cd "$WORKDIR"

git clone https://github.com/realies/librempeg.git librempeg
cd librempeg

mkdir -p "$WORKDIR/simple" "$WORKDIR/fixed"

# Simple = just-remove-limit-clean (no chunking optimization)
git show origin/just-remove-limit-clean:libavfilter/af_afade.c > "$WORKDIR/simple/af_afade.c"
git show origin/just-remove-limit-clean:libavfilter/afade_template.c > "$WORKDIR/simple/afade_template.c"

# Fixed = chunked output
git show origin/acrossfade-fix-chunked-output:libavfilter/af_afade.c > "$WORKDIR/fixed/af_afade.c"
git show origin/acrossfade-fix-chunked-output:libavfilter/afade_template.c > "$WORKDIR/fixed/afade_template.c"

cp -r . "$WORKDIR/librempeg-build"

docker run --rm -i \
    -v "$WORKDIR":/work \
    -w /build \
    ghcr.io/btbn/ffmpeg-builds/base-linux64:latest \
    bash -c '
set -e
apt-get update -qq && apt-get install -qq -y time bc >/dev/null 2>&1

echo "=== Building SIMPLE (just limit removal, no chunking) ==="
cp -r /work/librempeg-build/* .
cp /work/simple/af_afade.c libavfilter/
cp /work/simple/afade_template.c libavfilter/
./configure --enable-gpl --enable-version3 --enable-agpl --disable-doc --disable-network --quiet
make -j$(nproc) 2>&1 | tail -1
cp ffmpeg /ffmpeg-simple
cp ffprobe /ffprobe

echo "=== Building FIXED (chunked output) ==="
cp /work/fixed/af_afade.c libavfilter/
cp /work/fixed/afade_template.c libavfilter/
touch libavfilter/af_afade.c
make -j$(nproc) 2>&1 | tail -1
cp ffmpeg /ffmpeg-fixed

echo "=== Building BUGGY (PR #169 - current master) ==="
curl -sL "https://github.com/librempeg/librempeg/raw/master/libavfilter/af_afade.c" \
    -o libavfilter/af_afade.c
curl -sL "https://github.com/librempeg/librempeg/raw/master/libavfilter/afade_template.c" \
    -o libavfilter/afade_template.c
touch libavfilter/af_afade.c
make -j$(nproc) 2>&1 | tail -1
cp ffmpeg /ffmpeg-buggy

echo ""
echo "=== Creating test audio ==="
/ffmpeg-fixed -y -f lavfi -i "sine=frequency=440:duration=3900" -ar 44100 /tmp/in1.wav 2>/dev/null
/ffmpeg-fixed -y -f lavfi -i "sine=frequency=880:duration=3900" -ar 44100 /tmp/in2.wav 2>/dev/null
/ffmpeg-fixed -y -f lavfi -i "sine=frequency=440:duration=10" /tmp/in1_short.wav 2>/dev/null
/ffmpeg-fixed -y -f lavfi -i "sine=frequency=880:duration=3" /tmp/in2_short.wav 2>/dev/null

echo ""
echo "=== BUG TEST: Short input 2 (10s + 3s, 5s crossfade) ==="
echo "| Version | Output | Runtime |"
echo "|---------|--------|---------|"
for bin in simple buggy fixed; do
    START=$(date +%s.%N)
    timeout 30 /ffmpeg-$bin -y -i /tmp/in1_short.wav -i /tmp/in2_short.wav \
        -filter_complex "acrossfade=d=5:c1=tri:c2=tri" /tmp/out_$bin.wav 2>/dev/null || true
    END=$(date +%s.%N)
    if [ -f /tmp/out_$bin.wav ]; then
        DUR=$(/ffprobe -v error -show_entries format=duration -of csv=p=0 /tmp/out_$bin.wav 2>/dev/null || echo "N/A")
        TIME=$(echo "$END - $START" | bc)
        printf "| %-6s  | %-6s | %-7s |\n" "$bin" "${DUR}s" "${TIME}s"
    else
        printf "| %-6s  | N/A    | timeout |\n" "$bin"
    fi
done
echo "Expected: simple & fixed = 5s (correct), buggy = 8s and slow (broken)"

echo ""
echo "=== OUTPUT VERIFICATION (MD5) ==="
for d in 60 600 1800 3600; do
    /ffmpeg-simple -y -i /tmp/in1.wav -i /tmp/in2.wav \
        -filter_complex "acrossfade=d=${d}:c1=tri:c2=tri" /tmp/s.wav 2>/dev/null
    /ffmpeg-fixed -y -i /tmp/in1.wav -i /tmp/in2.wav \
        -filter_complex "acrossfade=d=${d}:c1=tri:c2=tri" /tmp/f.wav 2>/dev/null
    MD5_S=$(md5sum /tmp/s.wav | cut -d" " -f1)
    MD5_F=$(md5sum /tmp/f.wav | cut -d" " -f1)
    [ "$MD5_S" = "$MD5_F" ] && echo "$((d/60)) min: IDENTICAL" || echo "$((d/60)) min: DIFFER"
done

echo ""
echo "=== MEMORY: Simple vs Fixed ==="
echo "| Duration | Simple | Fixed | Reduction |"
echo "|----------|--------|-------|-----------|"
for d in 60 600 1800 3600; do
    mem_s=$(/usr/bin/time -v /ffmpeg-simple -y -i /tmp/in1.wav -i /tmp/in2.wav \
        -filter_complex "acrossfade=d=${d}:c1=tri:c2=tri" -f null - 2>&1 | \
        grep "Maximum resident" | awk "{print \$6}")
    mem_f=$(/usr/bin/time -v /ffmpeg-fixed -y -i /tmp/in1.wav -i /tmp/in2.wav \
        -filter_complex "acrossfade=d=${d}:c1=tri:c2=tri" -f null - 2>&1 | \
        grep "Maximum resident" | awk "{print \$6}")
    reduction=$(echo "scale=0; ($mem_s - $mem_f) * 100 / $mem_s" | bc)
    printf "| %2d min   | %4d MB | %4d MB | %3d%%      |\n" \
        "$((d/60))" "$((mem_s/1024))" "$((mem_f/1024))" "$reduction"
done

echo ""
echo "=== CPU (3 runs averaged) ==="
echo "| Duration | Simple | Fixed | Change |"
echo "|----------|--------|-------|--------|"
for d in 60 600 1800 3600; do
    ts=0; tf=0
    for i in 1 2 3; do
        t=$(/usr/bin/time -f "%e" /ffmpeg-simple -y -i /tmp/in1.wav -i /tmp/in2.wav \
            -filter_complex "acrossfade=d=${d}:c1=tri:c2=tri" -f null - 2>&1 | tail -1)
        ts=$(echo "$ts + $t" | bc)
        t=$(/usr/bin/time -f "%e" /ffmpeg-fixed -y -i /tmp/in1.wav -i /tmp/in2.wav \
            -filter_complex "acrossfade=d=${d}:c1=tri:c2=tri" -f null - 2>&1 | tail -1)
        tf=$(echo "$tf + $t" | bc)
    done
    as=$(echo "scale=2; $ts/3" | bc); af=$(echo "scale=2; $tf/3" | bc)
    if [ "$as" != "0" ] && [ "$as" != ".00" ]; then
        ch=$(echo "scale=0; (($af-$as)*100)/$as" | bc 2>/dev/null || echo "0")
        [ "$ch" -gt 0 ] 2>/dev/null && ch="+$ch"
    else
        ch="0"
    fi
    printf "| %2d min   | %5ss | %5ss | %4s%%   |\n" "$((d/60))" "$as" "$af" "$ch"
done

echo ""
echo "=== ALL TESTS COMPLETE ==="
'
```

</details>

## Note on Memory Comparison
The chunked output approach reduces peak memory by **31-43%** compared to simple limit removal, while producing byte-identical output. CPU performance is slightly improved (0-5% faster).
