### PR TITLE
Fix crash in ac4dec due to data misalignment

### DIFF
--- a/libavcodec/ac4dec_data.h
+++ b/libavcodec/ac4dec_data.h
@@ -1284,7 +1284,7 @@ static const uint32_t acpl_hcb_gamma_fine_dt_codes[81] = {
     0x031e10,
 };
 
-DECLARE_ASM_CONST(16, float, qwin)[640] = {
+DECLARE_ASM_CONST(32, float, qwin)[640] = {
     0,
     1.990318758627504e-004,  2.494762615491542e-004,  3.021769445225078e-004,
     3.548460080857985e-004,  4.058915811480806e-004,  4.546408052001889e-004,


### PR DESCRIPTION
Found this while tracing down a crash, turned out to be caused by insufficient alignment:

avcodec/ac4dec_data: qwin must be aligned by 32B

qwin is used in calls to s->fdsp->vector_fmul(). Deoending on CPU caps, the implementation of vector_fmul() can be set to ff_vector_fmul_avx() which in turn uses vmovaps and vmovaps requires 32 byte alignment.